### PR TITLE
Add NitroPool to coinbase_tags in BKC config

### DIFF
--- a/public/txt/mining-pools-configs/BKC/0.json
+++ b/public/txt/mining-pools-configs/BKC/0.json
@@ -38,7 +38,11 @@
       },
         "thepool.life": {
         "name": "Thepool.life",
-        "link": "Thepool.life"    
+        "link": "Thepool.life"
+      },
+        "NitroPool": {
+        "name": "NitroPool",
+        "link": "https://nitropool.net"    
       }
     },
       "payout_addresses": {


### PR DESCRIPTION
This PR adds NitroPool to the `coinbase_tags` list for Briskcoin, so blocks mined by our pool display correctly in the block explorer.

You can verify the tag is active in block [#477366] (https://explorer.briskcoin.org/block-height/477366), where `NitroPool` appears in the coinbase input.

Thanks for maintaining the project!